### PR TITLE
Add missing KMS resources to AWSCloudSpec

### DIFF
--- a/AWSCloudSpec.md
+++ b/AWSCloudSpec.md
@@ -238,6 +238,7 @@
 | Description | Mandatory |
 | ----------- | ---------- |
 | EKS cluster secret encryption key | Yes |
+| KMS key used to encrypt Kubernetes, VPC Flow, Amazon RDS for PostgreSQL and SSM Patch manager log groups within infrastructure &lt;_cluster_name_&gt; | Yes |
 
 ## ![AWS Identity and Access Management](https://raw.githubusercontent.com/awslabs/aws-icons-for-plantuml/main/dist/SecurityIdentityCompliance/IdentityandAccessManagement.png) AWS Identity and Access Management
 

--- a/logging.tf
+++ b/logging.tf
@@ -43,6 +43,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_logs_encry
 resource "aws_kms_key" "kms_key_cloudwatch_log_group" {
   description         = "KMS key used to encrypt Kubernetes, VPC Flow, Amazon RDS for PostgreSQL and SSM Patch manager log groups within infrastructure ${var.infrastructurename}"
   enable_key_rotation = true
+  tags                = var.tags
   policy              = <<POLICY
 {
     "Version": "2012-10-17",


### PR DESCRIPTION
This PR introduces `tags` to one of the KMS key resource, and adds KMS key to the AWSCloudSpec.md. 