### PR TITLE
Update README to document Terraform apply failure when deploying Amazon OpenSearch in new AWS accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,13 @@ Default timeout for node/addon deployment is 20 minutes, so please be patient.  
 always uncomment line `depends_on = [module.eks.node_groups]`.
 It is recommended to use AWS `admin` account, or ask your AWS administrator to assign necessary IAM roles and permissions to your user.
 
+When deploying an Amazon OpenSearch domain for the first time in a new AWS account using Terraform, you may encounter the following error:
+
+>**<span style="color:red">Error:</span>** creating OpenSearch Domain: ValidationException: Before you can proceed, you must enable a service-linked role to give Amazon OpenSearch Service permissions to access your VPC.
+
+This error occurs because Amazon OpenSearch requires a service-linked role to interact with your VPC. In a new AWS account, this role might not be created in time during the initial Terraform run, causing the domain provisioning to fail.
+
+Simply run `terraform apply` again. On the second attempt, the required service-linked role will already be in place, and the OpenSearch domain should be provisioned successfully.
 ### Destroy Infrastructure
 
 Resources that contain data, i.e. the databases, S3 storage, and the recovery points in the backup vault are protected against unintentional deletion.
@@ -339,7 +346,7 @@ To delete the S3 buckets that contains both versioned and non-versioned objects,
 $aws_profile = "<profile_name>"
 $buckets = terraform output s3_buckets | ConvertFrom-Json
 foreach ($bucket in $buckets) {
-    Write-Output "Deleting bucket: $bucket" 
+    Write-Output "Deleting bucket: $bucket"
     $deleteObjDict = @{}
     $deleteObj = New-Object System.Collections.ArrayList
     aws s3api list-object-versions --bucket $bucket --profile $aws_profile --query '[Versions[*].{ Key:Key , VersionId:VersionId} , DeleteMarkers[*].{ Key:Key , VersionId:VersionId}]' --output json `

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ When deploying an Amazon OpenSearch domain for the first time in a new AWS accou
 
 >**<span style="color:red">Error:</span>** creating OpenSearch Domain: ValidationException: Before you can proceed, you must enable a service-linked role to give Amazon OpenSearch Service permissions to access your VPC.
 
-This error occurs because Amazon OpenSearch requires a service-linked IAM role named `AWSServiceRoleForAmazonOpenSearchService` to interact with your VPC. In a new AWS account, this IAM role might not be created in time during the initial Terraform run, causing the domain provisioning to fail.
+This error occurs because Amazon OpenSearch requires a service-linked role named `AWSServiceRoleForAmazonOpenSearchService` to interact with your VPC. In a new AWS account, this role might not be created in time during the initial Terraform run, causing the domain provisioning to fail.
 
 Simply run `terraform apply` again. On the second attempt, the required service-linked role will already be in place, and the OpenSearch domain should be provisioned successfully.
 ### Destroy Infrastructure

--- a/README.md
+++ b/README.md
@@ -269,11 +269,17 @@ provider "aws" {
 
 Amazon OpenSearch requires a service-linked role named `AWSServiceRoleForAmazonOpenSearchService` to access resources within your VPC. If you're creating an Amazon OpenSearch domain for the first time in a new AWS account, this role may not yet exist. Before proceeding, check whether this role already exists in your account. If it doesn't, you can manually create it via the AWS Console:
 
-1. Navigate to IAM in the AWS Management Console.
+1. Navigate to IAM in the AWS Console.
 2. Click Create Role.
 3. Select **AWS service** as the trusted entity type.
 4. Choose **Amazon OpenSearch Service** from the list.
 5. Proceed with the default settings and create the role.
+
+You can also create the role via the AWS CLI:
+
+```sh
+aws iam create-service-linked-role  --aws-service-name opensearchservice.amazonaws.com --profile <profile_name>
+```
 
 ### Apply Terraform Configuration
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,15 @@ provider "aws" {
 +  profile = "<profile-name>"
 }
 ```
+### Setting Up Service-Linked Role for First-Time OpenSearch Domian Creation in an AWS Account
+
+Amazon OpenSearch requires a service-linked role named `AWSServiceRoleForAmazonOpenSearchService` to access resources within your VPC. If you're creating an Amazon OpenSearch domain for the first time in a new AWS account, this role may not yet exist. Before proceeding, check whether this role already exists in your account. If it doesn't, you can manually create it via the AWS Console:
+
+1. Navigate to IAM in the AWS Management Console.
+2. Click Create Role.
+3. Select **AWS service** as the trusted entity type.
+4. Choose **Amazon OpenSearch Service** from the list.
+5. Proceed with the default settings and create the role.
 
 ### Apply Terraform Configuration
 
@@ -288,11 +297,11 @@ Default timeout for node/addon deployment is 20 minutes, so please be patient.  
 always uncomment line `depends_on = [module.eks.node_groups]`.
 It is recommended to use AWS `admin` account, or ask your AWS administrator to assign necessary IAM roles and permissions to your user.
 
-When deploying an Amazon OpenSearch domain for the first time in a new AWS account using Terraform, you may encounter the following error:
+If the required service-linked role `AWSServiceRoleForAmazonOpenSearchService` is not manually created beforehand, setting up an Amazon OpenSearch domain for the first time in a new AWS account using Terraform may result in the following error:
 
 >**<span style="color:red">Error:</span>** creating OpenSearch Domain: ValidationException: Before you can proceed, you must enable a service-linked role to give Amazon OpenSearch Service permissions to access your VPC.
 
-This error occurs because Amazon OpenSearch requires a service-linked role named `AWSServiceRoleForAmazonOpenSearchService` to interact with your VPC. In a new AWS account, this role might not be created in time during the initial Terraform run, causing the domain provisioning to fail.
+This issue arises because, in a new AWS account, the required service-linked role may not be created in time during the initial Terraform run, causing the domain provisioning to fail.
 
 Simply run `terraform apply` again. On the second attempt, the required service-linked role will already be in place, and the OpenSearch domain should be provisioned successfully.
 ### Destroy Infrastructure

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ When deploying an Amazon OpenSearch domain for the first time in a new AWS accou
 
 >**<span style="color:red">Error:</span>** creating OpenSearch Domain: ValidationException: Before you can proceed, you must enable a service-linked role to give Amazon OpenSearch Service permissions to access your VPC.
 
-This error occurs because Amazon OpenSearch requires a service-linked role to interact with your VPC. In a new AWS account, this role might not be created in time during the initial Terraform run, causing the domain provisioning to fail.
+This error occurs because Amazon OpenSearch requires a service-linked IAM role named `AWSServiceRoleForAmazonOpenSearchService` to interact with your VPC. In a new AWS account, this IAM role might not be created in time during the initial Terraform run, causing the domain provisioning to fail.
 
 Simply run `terraform apply` again. On the second attempt, the required service-linked role will already be in place, and the OpenSearch domain should be provisioned successfully.
 ### Destroy Infrastructure

--- a/ivs-instances.tf
+++ b/ivs-instances.tf
@@ -26,3 +26,16 @@ module "ivs_instance" {
   log_bucket                           = aws_s3_bucket.bucket_logs.id
   depends_on                           = [module.k8s_eks_addons]
 }
+
+resource "aws_iam_service_linked_role" "opensearch" {
+  # count            = 0
+  aws_service_name = "opensearchservice.amazonaws.com"
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
+}
+
+import {
+  to = aws_iam_service_linked_role.opensearch
+  id = "arn:aws:iam::${local.aws_context.caller_identity_account_id}:role/aws-service-role/opensearchservice.amazonaws.com/AWSServiceRoleForAmazonOpenSearchService"
+}

--- a/ivs-instances.tf
+++ b/ivs-instances.tf
@@ -26,16 +26,3 @@ module "ivs_instance" {
   log_bucket                           = aws_s3_bucket.bucket_logs.id
   depends_on                           = [module.k8s_eks_addons]
 }
-
-resource "aws_iam_service_linked_role" "opensearch" {
-  # count            = 0
-  aws_service_name = "opensearchservice.amazonaws.com"
-  # lifecycle {
-  #   prevent_destroy = true
-  # }
-}
-
-import {
-  to = aws_iam_service_linked_role.opensearch
-  id = "arn:aws:iam::${local.aws_context.caller_identity_account_id}:role/aws-service-role/opensearchservice.amazonaws.com/AWSServiceRoleForAmazonOpenSearchService"
-}


### PR DESCRIPTION
This PR adds README note about Terraform failing on first OpenSearch domain deployment on a new AWS account due to missing service-linked role. The Updated README section looks like:

<img width="941" height="1016" alt="image" src="https://github.com/user-attachments/assets/c976ddca-c2ce-468b-9cd6-bc3271eb3688" />



