### PR TITLE
Fix codemeter download link

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -139,7 +139,7 @@ variable "licenseServer" {
 variable "codemeter" {
   type        = string
   description = "Download link for codemeter rpm package."
-  default     = "https://www.wibu.com/support/user/user-software/file/download/13346.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&cHash=8dba7ab094dec6267346f04fce2a2bcd"
+  default     = "https://www.wibu.com/support/user/user-software/file/download/15803.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&cHash=8dba7ab094dec6267346f04fce2a2bcd"
 }
 
 variable "kubernetesVersion" {


### PR DESCRIPTION
Existing Codemeter download link is no longer accessible. This PR introduces new download link, with newer version of Codemeter.